### PR TITLE
Dev allow admin to delete message

### DIFF
--- a/src/app/Http/Controllers/MessageController.php
+++ b/src/app/Http/Controllers/MessageController.php
@@ -107,9 +107,16 @@ class MessageController extends Controller
      */
     public function archive($id)
     {
-        $message = Message::where('id', $id)
+        $message = null;
+
+        if (Auth::user()->is_admin) {
+            $message = Message::where('id', $id)
+            ->delete();
+        } else {
+            $message = Message::where('id', $id)
             ->where('user_id', Auth::id())
             ->delete();
+        }
         
         if ( ! $message) {
             abort(404, 'Message not found');

--- a/src/tests/Feature/MessageTest.php
+++ b/src/tests/Feature/MessageTest.php
@@ -154,6 +154,24 @@ class MessageTest extends TestCase
         $this->assertSoftDeleted($message);
     }
 
+    public function testAdminCanArchiveMessage()
+    {
+        $message = Message::factory()->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        $admin = User::factory()->create([
+            'is_admin' => true,
+        ]);
+
+        Sanctum::actingAs($admin, ['*']);
+        
+        $this->delete('/api/messages/archive/' . $message->id)
+            ->assertOk();
+        
+        $this->assertSoftDeleted($message);
+    }
+
     public function testOtherUserCannotArchiveAMessage()
     {
         $message = Message::factory()->create();


### PR DESCRIPTION
## Context
Allow admin to delete user message

### Value
Admin can delete any user's messages.

### Changes
- Update message archive endpoint, admin or user that owns message can delete message.
- Add feature tests, checks admin can delete any user message.